### PR TITLE
Add tab navigation to EventPage

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -2,10 +2,15 @@
 import { useEventPage } from '@/hooks/useEventPage';
 import EventHeader from '@/components/event/EventHeader';
 import RegistrationControls from '@/components/event/RegistrationControls';
-import EventBody from '@/components/event/EventBody';
+import EventInfoForm from '@/components/event/EventInfoForm';
+import RegistrationSection from '@/components/event/RegistrationSection';
 import PageSkeleton from '@/components/PageSkeleton';
 import { useEffect, useState } from 'react';
 import ConfirmRevertDialog from '@/components/event/ConfirmRevertDialog';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import ArrangingEventSection from '@/components/ArrangingEventSection';
+import MatchesScheduleSection from '@/components/MatchesScheduleSection';
+import EventRanking from '@/components/event/EventRanking';
 
 export default function EventPage({ params }: { params: { id: string } }) {
   const {
@@ -26,49 +31,87 @@ export default function EventPage({ params }: { params: { id: string } }) {
     return () => clearTimeout(timer)
   }, [showRevertModal, countdown])
 
+  const [tab, setTab] = useState<'event' | 'match' | 'ranking'>('event')
+
   if (!event) return <PageSkeleton />;
 
   return (
     <div className="p-4 space-y-6">
-      <EventHeader
-        event={event}
-        isAdmin={isAdmin}
-        onPrev={() => {
-          if (isAdmin && event.status === 'arranging') {
-            setCountdown(5)
-            setShowRevertModal(true)
-          } else {
-            actions.prevStep()
-          }
-        }}
-        onNext={actions.nextStep}
-      />
+      <Tabs value={tab} onValueChange={v => setTab(v as any)}>
+        <TabsList className="mb-4">
+          <TabsTrigger value="event">Event</TabsTrigger>
+          <TabsTrigger value="match">Match</TabsTrigger>
+          <TabsTrigger value="ranking">Ranking</TabsTrigger>
+        </TabsList>
 
-      <RegistrationControls
-        canRegister={canRegister}
-        canUnregister={canUnregister}
-        onRegister={actions.joinEvent}
-        onUnregister={actions.leaveEvent}
-      />
+        <TabsContent value="event">
+          <EventHeader
+            event={event}
+            isAdmin={isAdmin}
+            onPrev={() => {
+              if (isAdmin && event.status === 'arranging') {
+                setCountdown(5)
+                setShowRevertModal(true)
+              } else {
+                actions.prevStep()
+              }
+            }}
+            onNext={actions.nextStep}
+          />
 
-      <EventBody
-        status={event.status}
-        participants={event.participants}
-        groups={groups}
-        matches={matches}
-        actions={actions}
-        isAdmin={isAdmin}
-        user={session?.user}
-      />
+          <RegistrationControls
+            canRegister={canRegister}
+            canUnregister={canUnregister}
+            onRegister={actions.joinEvent}
+            onUnregister={actions.leaveEvent}
+          />
 
-      <ConfirmRevertDialog
-        open={showRevertModal}
-        onClose={() => setShowRevertModal(false)}
-        onConfirm={async () => {
-          await actions.deleteAllMatches()
-          await actions.prevStep()
-        }}
-      />
+          <div className="space-y-4">
+            <EventInfoForm event={event} isAdmin={isAdmin} onSave={actions.updateInfo} />
+            {(event.status === 'preparing' || event.status === 'registration') && (
+              <RegistrationSection
+                participants={event.participants}
+                currentUserId={session?.user?.id}
+                isAdmin={isAdmin}
+                onRemoveParticipant={actions.removeParticipant}
+              />
+            )}
+          </div>
+
+          <ConfirmRevertDialog
+            open={showRevertModal}
+            onClose={() => setShowRevertModal(false)}
+            onConfirm={async () => {
+              await actions.deleteAllMatches()
+              await actions.prevStep()
+            }}
+          />
+        </TabsContent>
+
+        <TabsContent value="match">
+          {event.status === 'arranging' ? (
+            matches.length > 0 ? (
+              <MatchesScheduleSection matches={matches} />
+            ) : (
+              <ArrangingEventSection
+                groups={groups}
+                onGroupsChange={actions.saveGroups}
+                onGenerateGroups={actions.generateGroups}
+                onGenerateMatches={actions.generateMatches}
+              />
+            )
+          ) : (
+            <MatchesScheduleSection
+              matches={matches}
+              onScoreUpdated={actions.updateMatchScore}
+            />
+          )}
+        </TabsContent>
+
+        <TabsContent value="ranking">
+          <EventRanking matches={matches} />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/app/events/[id]/ranking/page.tsx
+++ b/app/events/[id]/ranking/page.tsx
@@ -2,52 +2,18 @@
 
 import { useEventPage } from '@/hooks/useEventPage'
 import PageSkeleton from '@/components/PageSkeleton'
-import UserCard from '@/components/UserCard'
+import EventRanking from '@/components/event/EventRanking'
 
 export default function EventRankingPage({ params }: { params: { id: string } }) {
-  const {
-    event,
-    matches,
-  } = useEventPage(params.id)
+  const { event, matches } = useEventPage(params.id)
 
   if (!event) {
     return <PageSkeleton />
   }
 
-  const rankingMap: Record<string, { user: any; margin: number }> = {}
-
-  matches.forEach(match => {
-    const [a, b] = match.teams
-    if (a.score !== b.score) {
-      const winning = a.score > b.score ? a : b
-      const margin = Math.abs(a.score - b.score)
-      winning.players.forEach((p: any) => {
-        const pid = p.id
-        if (!rankingMap[pid]) {
-          rankingMap[pid] = { user: p, margin: 0 }
-        }
-        rankingMap[pid].margin += margin
-      })
-    }
-  })
-
-  const ranking = Object.values(rankingMap).sort((x, y) => y.margin - x.margin)
-
   return (
-    <div className="p-4 space-y-4">
-      <h1 className="text-xl font-semibold">Ranking</h1>
-      <div className="space-y-2">
-        {ranking.length === 0 ? (
-          <p>No results yet.</p>
-        ) : (
-          ranking.map(r => (
-            <div key={r.user.id} className="flex justify-between items-center">
-              <UserCard user={r.user} />
-              <span className="font-semibold">{r.margin}</span>
-            </div>
-          ))
-        )}
-      </div>
+    <div className="p-4">
+      <EventRanking matches={matches} />
     </div>
   )
 }

--- a/components/event/EventInfoForm.tsx
+++ b/components/event/EventInfoForm.tsx
@@ -1,0 +1,129 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '@/components/ui/select'
+
+interface Props {
+  event: any
+  isAdmin: boolean
+  onSave: (data: {
+    name: string
+    visibility: string
+    registrationEndTime?: string
+    location?: string
+    gameStyle?: string
+    maxPoint?: number
+    courtCount?: number
+    umpires?: string[]
+  }) => void
+}
+
+export default function EventInfoForm({ event, isAdmin, onSave }: Props) {
+  const [name, setName] = useState('')
+  const [visibility, setVisibility] = useState('private')
+  const [regEnd, setRegEnd] = useState('')
+  const [location, setLocation] = useState('')
+  const [gameStyle, setGameStyle] = useState('')
+  const [maxPoint, setMaxPoint] = useState('')
+  const [courtCount, setCourtCount] = useState('')
+  const [umpires, setUmpires] = useState('')
+
+  useEffect(() => {
+    if (!event) return
+    setName(event.name || '')
+    setVisibility(event.visibility || 'private')
+    setRegEnd(event.registrationEndTime ? event.registrationEndTime.slice(0, 16) : '')
+    setLocation(event.location || '')
+    setGameStyle(event.gameStyle || '')
+    setMaxPoint(event.maxPoint != null ? String(event.maxPoint) : '')
+    setCourtCount(event.courtCount != null ? String(event.courtCount) : '')
+    setUmpires(event.umpires ? event.umpires.join(',') : '')
+  }, [event])
+
+  const handleSave = () => {
+    onSave({
+      name,
+      visibility,
+      registrationEndTime: regEnd || undefined,
+      location,
+      gameStyle,
+      maxPoint: maxPoint ? Number(maxPoint) : undefined,
+      courtCount: courtCount ? Number(courtCount) : undefined,
+      umpires: umpires
+        .split(',')
+        .map(u => u.trim())
+        .filter(u => u.length > 0),
+    })
+  }
+
+  return (
+    <div className="space-y-2 max-w-sm">
+      <Input
+        value={name}
+        onChange={e => setName(e.target.value)}
+        placeholder="name"
+        disabled={!isAdmin}
+      />
+      <Select value={visibility} onValueChange={setVisibility} disabled={!isAdmin}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="visibility" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="private">private</SelectItem>
+          <SelectItem value="public-view">public-view</SelectItem>
+          <SelectItem value="public-join">public-join</SelectItem>
+        </SelectContent>
+      </Select>
+      <Input
+        type="datetime-local"
+        value={regEnd}
+        onChange={e => setRegEnd(e.target.value)}
+        disabled={!isAdmin}
+      />
+      <Input
+        value={location}
+        onChange={e => setLocation(e.target.value)}
+        placeholder="location"
+        disabled={!isAdmin}
+      />
+      <Input
+        value={gameStyle}
+        onChange={e => setGameStyle(e.target.value)}
+        placeholder="game style"
+        disabled={!isAdmin}
+      />
+      <Input
+        type="number"
+        value={maxPoint}
+        onChange={e => setMaxPoint(e.target.value)}
+        placeholder="max point"
+        disabled={!isAdmin}
+      />
+      <Input
+        type="number"
+        value={courtCount}
+        onChange={e => setCourtCount(e.target.value)}
+        placeholder="court count"
+        disabled={!isAdmin}
+      />
+      <Input
+        value={umpires}
+        onChange={e => setUmpires(e.target.value)}
+        placeholder="umpire ids (comma separated)"
+        disabled={!isAdmin}
+      />
+      {isAdmin && (
+        <Button onClick={handleSave} className="w-full">
+          Save
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/components/event/EventRanking.tsx
+++ b/components/event/EventRanking.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import UserCard from '@/components/UserCard'
+import { MatchUI } from '@/components/MatchesScheduleSection'
+
+export default function EventRanking({ matches }: { matches: MatchUI[] }) {
+  const rankingMap: Record<string, { user: any; margin: number }> = {}
+
+  matches.forEach(match => {
+    const [a, b] = match.teams
+    if (a.score !== b.score) {
+      const winning = a.score > b.score ? a : b
+      const margin = Math.abs(a.score - b.score)
+      winning.players.forEach((p: any) => {
+        const pid = p.id
+        if (!rankingMap[pid]) {
+          rankingMap[pid] = { user: p, margin: 0 }
+        }
+        rankingMap[pid].margin += margin
+      })
+    }
+  })
+
+  const ranking = Object.values(rankingMap).sort((x, y) => y.margin - x.margin)
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Ranking</h1>
+      <div className="space-y-2">
+        {ranking.length === 0 ? (
+          <p>No results yet.</p>
+        ) : (
+          ranking.map(r => (
+            <div key={r.user.id} className="flex justify-between items-center">
+              <UserCard user={r.user} />
+              <span className="font-semibold">{r.margin}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/hooks/useEventPage.ts
+++ b/hooks/useEventPage.ts
@@ -71,6 +71,13 @@ export function useEventPage(eventId: string) {
     // All your action functions:
     const joinEvent = async () => { await request({ url: `/api/events/${eventId}`, method: 'post' }); fetchEvent() };
     const leaveEvent = async () => { await request({ url: `/api/events/${eventId}/leave`, method: 'delete', }); fetchEvent(); };
+    const removeParticipant = async (pid: string) => {
+        await request({
+            url: `/api/events/${eventId}?participantId=${pid}`,
+            method: 'delete',
+        });
+        fetchEvent();
+    };
     const saveInfo = async (data: any) => {
         await request({
             url: `/api/events/${eventId}`,
@@ -84,6 +91,14 @@ export function useEventPage(eventId: string) {
                 maxPoint: event.editingMaxPoint ? Number(event.editingMaxPoint) : undefined,
                 courtCount: event.editingCourtCount ? Number(event.editingCourtCount) : undefined,
             },
+        });
+        fetchEvent();
+    };
+    const updateInfo = async (info: any) => {
+        await request({
+            url: `/api/events/${eventId}`,
+            method: 'put',
+            data: info,
         });
         fetchEvent();
     };
@@ -166,7 +181,8 @@ export function useEventPage(eventId: string) {
         canRegister, canUnregister,
         actions: {
             fetchEvent, joinEvent, leaveEvent,
-            saveInfo, nextStep, prevStep,
+            removeParticipant,
+            saveInfo, updateInfo, nextStep, prevStep,
             generateGroups, saveGroups,
             generateMatches, deleteAllMatches,
             updateCourtCount, updateMatchScore,


### PR DESCRIPTION
## Summary
- implement `EventRanking` component for reuse
- update event ranking route to use shared component
- add editable form under Event tab
- show participants only in Event tab

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685a5fed584c8322b1999154ebf5f7c3