### PR TITLE
Implement login password reset

### DIFF
--- a/app/api/request-password-reset/route.ts
+++ b/app/api/request-password-reset/route.ts
@@ -6,13 +6,14 @@ import PasswordReset from '@/models/PasswordReset';
 import { randomBytes } from 'crypto';
 import { Resend } from 'resend';
 
-export async function POST() {
+export async function POST(request: Request) {
   const session = await getServerSession(authOptions);
-  if (!session || !session.user.email) {
-    return NextResponse.json({ success: false }, { status: 401 });
+  const body = await request.json().catch(() => ({}));
+  const email = body.email || session?.user?.email;
+  if (!email) {
+    return NextResponse.json({ success: false }, { status: 400 });
   }
   await connect();
-  const email = session.user.email;
 
   await PasswordReset.deleteMany({ email });
   const token = randomBytes(32).toString('hex');

--- a/app/api/reset-password/route.ts
+++ b/app/api/reset-password/route.ts
@@ -10,7 +10,9 @@ export async function POST(request: Request) {
     return NextResponse.json({ success: false }, { status: 400 });
   }
   await connect();
+  
   const entry = await PasswordReset.findOne({ token });
+  
   if (!entry) {
     return NextResponse.json({ success: false }, { status: 400 });
   }

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { useState } from 'react';
+import Link from 'next/link';
+import { Button } from '../../components/ui/button';
+import { Input } from '../../components/ui/input';
+import { useApi } from '../../lib/useApi';
+
+export default function ForgotPasswordPage() {
+  const { request } = useApi();
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async () => {
+    setMessage('');
+    try {
+      await request({
+        url: '/api/request-password-reset',
+        method: 'post',
+        data: { email },
+      });
+      setSent(true);
+    } catch {
+      setMessage('Failed to send reset email');
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-xs py-8">
+      <h1 className="text-2xl font-semibold mb-4">Reset Password</h1>
+      {sent ? (
+        <p>Please check your email for a password reset link.</p>
+      ) : (
+        <div className="space-y-4">
+          <Input
+            placeholder="Email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+          />
+          {message && <p className="text-red-500 text-sm">{message}</p>}
+          <Button className="w-full" onClick={handleSubmit}>
+            Send Reset Email
+          </Button>
+          <Button variant="outline" className="w-full" asChild>
+            <Link href="/login">Back to Login</Link>
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -51,6 +51,9 @@ export default function LoginPage() {
         <Button variant="outline" className="w-full" asChild>
           <Link href="/signup">Sign Up</Link>
         </Button>
+        <Button variant="link" className="w-full p-0" asChild>
+          <Link href="/forgot-password">Forgot Password?</Link>
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a dedicated **Forgot Password** page
- expose password reset request API for anonymous users
- link to the reset flow from the login page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b3daab9508321a3f657985c85c805