### PR TITLE
Add floating labels to event info form

### DIFF
--- a/app/i18n/en/common.json
+++ b/app/i18n/en/common.json
@@ -58,6 +58,7 @@
     "visibility.private": "private",
     "visibility.publicView": "public-view",
     "visibility.publicJoin": "public-join",
+    "registrationEndTime": "Registration Deadline",
     "gameStyle": "game style",
     "maxPoint": "max point",
     "totalCourt": "total court",

--- a/app/i18n/es/common.json
+++ b/app/i18n/es/common.json
@@ -59,6 +59,7 @@
     "visibility.private": "privado",
     "visibility.publicView": "público (solo vista)",
     "visibility.publicJoin": "público (puede unirse)",
+    "registrationEndTime": "Fecha límite de registro",
     "gameStyle": "estilo de juego",
     "maxPoint": "puntos máximos",
     "totalCourt": "total de canchas",

--- a/app/i18n/vi/common.json
+++ b/app/i18n/vi/common.json
@@ -59,6 +59,7 @@
     "visibility.private": "riêng tư",
     "visibility.publicView": "công khai (chỉ xem)",
     "visibility.publicJoin": "công khai (tham gia)",
+    "registrationEndTime": "Hạn chót đăng ký",
     "gameStyle": "phong cách trò chơi",
     "maxPoint": "điểm tối đa",
     "totalCourt": "số sân",

--- a/app/i18n/zh/common.json
+++ b/app/i18n/zh/common.json
@@ -59,6 +59,7 @@
   "visibility.private": "私有",
   "visibility.publicView": "公开查看",
   "visibility.publicJoin": "公开加入",
+  "registrationEndTime": "报名截止时间",
   "gameStyle": "比赛风格",
   "maxPoint": "最高得分",
   "totalCourt": "总场地数",

--- a/components/event/EventInfoForm.tsx
+++ b/components/event/EventInfoForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useState, useEffect } from 'react'
-import { Input } from '@/components/ui/input'
+import { FloatingLabelInput } from '@/components/ui/floating-label-input'
+import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import {
   Select,
@@ -66,59 +67,69 @@ export default function EventInfoForm({ event, isAdmin, onSave }: Props) {
   }
 
   return (
-    <div className="space-y-2 max-w-sm">
-      <Input
+    <div className="space-y-4 max-w-sm">
+      <FloatingLabelInput
         value={name}
         onChange={e => setName(e.target.value)}
-        placeholder={t('name')}
+        label={t('name')}
         disabled={!isAdmin}
       />
-      <Select value={visibility} onValueChange={setVisibility} disabled={!isAdmin}>
-        <SelectTrigger className="w-full">
-          <SelectValue placeholder={t('visibility')} />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="private">{t('private')}</SelectItem>
-          <SelectItem value="public-view">{t('publicView')}</SelectItem>
-          <SelectItem value="public-join">{t('publicJoin')}</SelectItem>
-        </SelectContent>
-      </Select>
-      <Input
+      <div className="space-y-1">
+        <Label htmlFor="visibility-select" className="text-sm">
+          {t('visibility')}
+        </Label>
+        <Select
+          value={visibility}
+          onValueChange={setVisibility}
+          disabled={!isAdmin}
+        >
+          <SelectTrigger id="visibility-select" className="w-full">
+            <SelectValue placeholder={t('visibility')} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="private">{t('private')}</SelectItem>
+            <SelectItem value="public-view">{t('publicView')}</SelectItem>
+            <SelectItem value="public-join">{t('publicJoin')}</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <FloatingLabelInput
         type="datetime-local"
         value={regEnd}
         onChange={e => setRegEnd(e.target.value)}
+        label={t('registrationEndTime')}
         disabled={!isAdmin}
       />
-      <Input
+      <FloatingLabelInput
         value={location}
         onChange={e => setLocation(e.target.value)}
-        placeholder={t('locationPlace')}
+        label={t('locationPlace')}
         disabled={!isAdmin}
       />
-      <Input
+      <FloatingLabelInput
         value={gameStyle}
         onChange={e => setGameStyle(e.target.value)}
-        placeholder={t('gameStyle')}
+        label={t('gameStyle')}
         disabled={!isAdmin}
       />
-      <Input
+      <FloatingLabelInput
         type="number"
         value={maxPoint}
         onChange={e => setMaxPoint(e.target.value)}
-        placeholder={t('maxPoint')}
+        label={t('maxPoint')}
         disabled={!isAdmin}
       />
-      <Input
+      <FloatingLabelInput
         type="number"
         value={courtCount}
         onChange={e => setCourtCount(e.target.value)}
-        placeholder={t('courtCount')}
+        label={t('courtCount')}
         disabled={!isAdmin}
       />
-      <Input
+      <FloatingLabelInput
         value={umpires}
         onChange={e => setUmpires(e.target.value)}
-        placeholder={t('umpireIds')}
+        label={t('umpireIds')}
         disabled={!isAdmin}
       />
       {isAdmin && (

--- a/components/ui/floating-label-input.tsx
+++ b/components/ui/floating-label-input.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const FloatingInput = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => {
+    return <Input placeholder=" " className={cn('peer', className)} ref={ref} {...props} />
+  },
+)
+FloatingInput.displayName = 'FloatingInput'
+
+const FloatingLabel = React.forwardRef<
+  React.ElementRef<typeof Label>,
+  React.ComponentPropsWithoutRef<typeof Label>
+>(({ className, ...props }, ref) => {
+  return (
+    <Label
+      className={cn(
+        'peer-focus:secondary peer-focus:dark:secondary absolute start-2 top-2 z-10 origin-[0] -translate-y-4 scale-75 transform bg-background px-2 text-sm text-gray-500 duration-300 peer-placeholder-shown:top-1/2 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:scale-100 peer-focus:top-2 peer-focus:-translate-y-4 peer-focus:scale-75 peer-focus:px-2 dark:bg-background rtl:peer-focus:left-auto rtl:peer-focus:translate-x-1/4 cursor-text',
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  )
+})
+FloatingLabel.displayName = 'FloatingLabel'
+
+type FloatingLabelInputProps = InputProps & { label?: string }
+
+const FloatingLabelInput = React.forwardRef<
+  React.ElementRef<typeof FloatingInput>,
+  React.PropsWithoutRef<FloatingLabelInputProps>
+>(({ id, label, ...props }, ref) => {
+  return (
+    <div className="relative">
+      <FloatingInput ref={ref} id={id} {...props} />
+      <FloatingLabel htmlFor={id}>{label}</FloatingLabel>
+    </div>
+  )
+})
+FloatingLabelInput.displayName = 'FloatingLabelInput'
+
+export { FloatingInput, FloatingLabel, FloatingLabelInput }


### PR DESCRIPTION
## Summary
- add floating label input component based on shadcn-ui expansions
- localize and label registration end time for all languages
- update EventInfoForm to use floating labels

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c21c8637483228073acb2d1d29c02