### PR TITLE
Add Google Maps location autocomplete

### DIFF
--- a/app/api/places/autocomplete/route.ts
+++ b/app/api/places/autocomplete/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const input = url.searchParams.get('input');
+  if (!input) {
+    return NextResponse.json({ predictions: [] });
+  }
+  const key = process.env.GOOGLE_MAPS_API_KEY || process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY;
+  if (!key) {
+    console.error('Google Maps API key not configured');
+    return NextResponse.json({ predictions: [] }, { status: 500 });
+  }
+  try {
+    const res = await fetch(
+      `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${encodeURIComponent(input)}&key=${key}`
+    );
+    const data = await res.json();
+    return NextResponse.json({ predictions: data.predictions || [] });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ predictions: [] }, { status: 500 });
+  }
+}

--- a/app/clubs/[id]/page.tsx
+++ b/app/clubs/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { Input } from '../../../components/ui/input';
+import LocationAutocomplete from '../../../components/LocationAutocomplete';
 import { Button } from '../../../components/ui/button';
 import ConfirmLeaveDialog from '../../../components/club/ConfirmLeaveDialog';
 import ClubMap from '../../../components/club/ClubMap';
@@ -172,11 +173,10 @@ export default function ClubHome({ params }: { params: { id: string } }) {
       )}
       {isAdmin && (
         <div className="space-x-2 mt-2 flex items-center">
-          <Input
+          <LocationAutocomplete
             placeholder="Club location"
             value={clubLocation}
-            onChange={e => setClubLocation(e.target.value)}
-            className="flex-1"
+            onChange={setClubLocation}
           />
           <Button onClick={updateLocation} disabled={savingLocation}>Save</Button>
         </div>

--- a/app/clubs/[id]/page.tsx
+++ b/app/clubs/[id]/page.tsx
@@ -203,7 +203,7 @@ export default function ClubHome({ params }: { params: { id: string } }) {
                 value={newEventName}
                 onChange={e => setNewEventName(e.target.value)}
                 placeholder={t('eventTitle')}
-                className="w-48"
+                className="w-64 flex-1"
               />
               <Button onClick={createEvent}>{t('createEvent')}</Button>
             </div>

--- a/app/i18n/en/common.json
+++ b/app/i18n/en/common.json
@@ -56,6 +56,7 @@
     "createEvent": "Create Event",
     "joinClub": "Join us!",
     "membersJoined": "Members",
+    "getDirections": "Get Directions",
     "name": "name",
     "visibility": "visibility",
     "visibility.private": "private",

--- a/app/i18n/es/common.json
+++ b/app/i18n/es/common.json
@@ -57,6 +57,7 @@
     "createEvent": "Crear evento",
     "joinClub": "Únete a nosotros!",
     "membersJoined": "Miembros",
+    "getDirections": "Obtener direcciones",
     "name": "nombre",
     "visibility": "visibilidad",
     "visibility.private": "privado",

--- a/app/i18n/vi/common.json
+++ b/app/i18n/vi/common.json
@@ -57,6 +57,7 @@
     "createEvent": "Tạo sự kiện",
     "joinClub": "Tham gia chúng tôi!",
     "membersJoined": "Thành viên",
+    "getDirections": "Chỉ đường",
     "name": "tên",
     "visibility": "hiển thị",
     "visibility.private": "riêng tư",

--- a/app/i18n/zh/common.json
+++ b/app/i18n/zh/common.json
@@ -57,6 +57,7 @@
   "createEvent": "创建活动",
   "joinClub": "加入我们！",
   "membersJoined": "成员",
+  "getDirections": "路线指引",
   "name": "名称",
   "visibility": "可见性",
   "visibility.private": "私有",

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -12,6 +12,7 @@ import {
   SelectItem,
 } from '../../components/ui/select';
 import { Input } from '../../components/ui/input';
+import LocationAutocomplete from '../../components/LocationAutocomplete';
 import { Button } from '../../components/ui/button';
 import ClubCard from '../../components/ClubCard';
 import Link from 'next/link';
@@ -189,11 +190,10 @@ export default function ManagePage() {
             onChange={e => setClubName(e.target.value)}
             className="flex-1"
           />
-          <Input
+          <LocationAutocomplete
             placeholder={t('locationPlace')}
             value={clubLocation}
-            onChange={e => setClubLocation(e.target.value)}
-            className="flex-1"
+            onChange={setClubLocation}
           />
           <Select
             value={clubVisibility}

--- a/components/LocationAutocomplete.tsx
+++ b/components/LocationAutocomplete.tsx
@@ -49,7 +49,7 @@ export default function LocationAutocomplete({ value, onChange, placeholder }: P
   }
 
   return (
-    <div className="relative">
+    <div className="relative w-full">
       <Input
         placeholder={placeholder}
         value={query}
@@ -61,7 +61,7 @@ export default function LocationAutocomplete({ value, onChange, placeholder }: P
         }}
         onFocus={() => query && suggestions.length > 0 && setOpen(true)}
         onBlur={() => setTimeout(() => setOpen(false), 100)}
-        className="flex-1"
+        className="w-full flex-1"
       />
       {open && suggestions.length > 0 && (
         <div className="absolute z-10 w-full bg-white border rounded shadow max-h-60 overflow-y-auto">

--- a/components/LocationAutocomplete.tsx
+++ b/components/LocationAutocomplete.tsx
@@ -24,9 +24,7 @@ export default function LocationAutocomplete({ value, onChange, placeholder }: P
         return
       }
       try {
-        const res = await fetch(
-          `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${encodeURIComponent(query)}&key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}`
-        )
+        const res = await fetch(`/api/places/autocomplete?input=${encodeURIComponent(query)}`)
         const data = await res.json()
         if (data.predictions) {
           setSuggestions(data.predictions.map((p: any) => p.description))

--- a/components/LocationAutocomplete.tsx
+++ b/components/LocationAutocomplete.tsx
@@ -59,21 +59,30 @@ export default function LocationAutocomplete({ value, onChange, placeholder }: P
         }}
         onFocus={() => query && suggestions.length > 0 && setOpen(true)}
         onBlur={() => setTimeout(() => setOpen(false), 100)}
-        className="w-full flex-1"
+        className="w-full"
       />
       {open && suggestions.length > 0 && (
-        <div className="absolute z-10 w-full bg-white border rounded shadow max-h-60 overflow-y-auto">
+        <div className="absolute z-20 w-full bg-white border border-gray-200 rounded-lg shadow-lg mt-1 max-h-60 overflow-y-auto animate-fade-in">
           {suggestions.map((s, idx) => (
             <div
               key={idx}
               onMouseDown={() => handleSelect(s)}
-              className="px-2 py-1 cursor-pointer hover:bg-gray-100"
+              className="px-4 py-2 cursor-pointer transition-colors duration-150 hover:bg-blue-50 hover:text-blue-700 text-gray-800 text-sm first:rounded-t-lg last:rounded-b-lg"
             >
-              {s}
+              <span className="truncate block">{s}</span>
             </div>
           ))}
         </div>
       )}
+      <style jsx global>{`
+        @keyframes fade-in {
+          from { opacity: 0; transform: translateY(-4px);}
+          to { opacity: 1; transform: translateY(0);}
+        }
+        .animate-fade-in {
+          animation: fade-in 0.15s ease;
+        }
+      `}</style>
     </div>
   )
 }

--- a/components/LocationAutocomplete.tsx
+++ b/components/LocationAutocomplete.tsx
@@ -1,0 +1,81 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { Input } from './ui/input'
+
+interface Props {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+}
+
+export default function LocationAutocomplete({ value, onChange, placeholder }: Props) {
+  const [query, setQuery] = useState(value)
+  const [suggestions, setSuggestions] = useState<string[]>([])
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    setQuery(value)
+  }, [value])
+
+  useEffect(() => {
+    const fetchPlaces = async () => {
+      if (!query) {
+        setSuggestions([])
+        return
+      }
+      try {
+        const res = await fetch(
+          `https://maps.googleapis.com/maps/api/place/autocomplete/json?input=${encodeURIComponent(query)}&key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY}`
+        )
+        const data = await res.json()
+        if (data.predictions) {
+          setSuggestions(data.predictions.map((p: any) => p.description))
+        } else {
+          setSuggestions([])
+        }
+      } catch (err) {
+        console.error(err)
+        setSuggestions([])
+      }
+    }
+    const t = setTimeout(fetchPlaces, 300)
+    return () => clearTimeout(t)
+  }, [query])
+
+  const handleSelect = (place: string) => {
+    setQuery(place)
+    onChange(place)
+    setOpen(false)
+  }
+
+  return (
+    <div className="relative">
+      <Input
+        placeholder={placeholder}
+        value={query}
+        onChange={e => {
+          const val = e.target.value
+          setQuery(val)
+          onChange(val)
+          setOpen(true)
+        }}
+        onFocus={() => query && suggestions.length > 0 && setOpen(true)}
+        onBlur={() => setTimeout(() => setOpen(false), 100)}
+        className="flex-1"
+      />
+      {open && suggestions.length > 0 && (
+        <div className="absolute z-10 w-full bg-white border rounded shadow max-h-60 overflow-y-auto">
+          {suggestions.map((s, idx) => (
+            <div
+              key={idx}
+              onMouseDown={() => handleSelect(s)}
+              className="px-2 py-1 cursor-pointer hover:bg-gray-100"
+            >
+              {s}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/club/ClubMap.tsx
+++ b/components/club/ClubMap.tsx
@@ -47,9 +47,9 @@ export default function ClubMap({ location }: ClubMapProps) {
           loading="lazy"
         />
       </div>
-      <div className="flex items-center space-x-2 mt-2">
+      <div className="w-full flex items-center space-x-2 mt-2">
         <Select value={provider} onValueChange={setProvider}>
-          <SelectTrigger className="w-[160px]">
+          <SelectTrigger className="w-full flex-1">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/components/club/ClubMap.tsx
+++ b/components/club/ClubMap.tsx
@@ -1,20 +1,65 @@
-'use client'
+"use client"
+
+import { useState } from 'react'
+import { Button } from '../ui/button'
+import { useTranslation } from 'react-i18next'
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from '../ui/select'
 
 interface ClubMapProps {
   location: string
 }
 
 export default function ClubMap({ location }: ClubMapProps) {
+  const { t } = useTranslation('common')
+  const [provider, setProvider] = useState('google')
+
   const src = `https://maps.google.com/maps?q=${encodeURIComponent(location)}&z=13&output=embed`
+
+  const getDirectionUrl = () => {
+    switch (provider) {
+      case 'apple':
+        return `https://maps.apple.com/?daddr=${encodeURIComponent(location)}`
+      case 'bing':
+        return `https://www.bing.com/maps?rtp=~adr.${encodeURIComponent(location)}`
+      default:
+        return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(location)}`
+    }
+  }
+
+  const openDirections = () => {
+    window.open(getDirectionUrl(), '_blank')
+  }
+
   return (
-    <div className="w-full h-64 border rounded-md overflow-hidden">
-      <iframe
-        title="Club location map"
-        src={src}
-        width="100%"
-        height="100%"
-        loading="lazy"
-      />
+    <div>
+      <div className="w-full h-64 border rounded-md overflow-hidden">
+        <iframe
+          title="Club location map"
+          src={src}
+          width="100%"
+          height="100%"
+          loading="lazy"
+        />
+      </div>
+      <div className="flex items-center space-x-2 mt-2">
+        <Select value={provider} onValueChange={setProvider}>
+          <SelectTrigger className="w-[160px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="google">Google Maps</SelectItem>
+            <SelectItem value="apple">Apple Maps</SelectItem>
+            <SelectItem value="bing">Bing Maps</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button onClick={openDirections}>{t('getDirections')}</Button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add `LocationAutocomplete` component that fetches from Google Maps API
- replace location input in Manage page with the autocomplete dropdown
- update club location editing to use the new dropdown

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c8bcb4d088321894a14856e67d508