### PR TITLE
Fix profile image caching

### DIFF
--- a/app/api/clubs/[id]/route.ts
+++ b/app/api/clubs/[id]/route.ts
@@ -15,14 +15,14 @@ export async function GET(
     return NextResponse.json({ success: false }, { status: 401 });
   }
   await connect();
-  const club: any = await Club.findById(params.id).populate('adminList', 'username nickname image').lean();
+  const club: any = await Club.findById(params.id).populate('adminList', 'username nickname image avatarUpdatedAt').lean();
   if (!club) {
     return NextResponse.json({ success: false }, { status: 404 });
   }
   const memberIds = club.members.map((m: any) => m.id);
   const members: any[] = await User.find(
     { _id: { $in: memberIds } },
-    { username: 1, nickname: 1, gender: 1, image: 1, role: 1 }
+    { username: 1, nickname: 1, gender: 1, image: 1, role: 1, avatarUpdatedAt: 1 }
   ).lean();
   const events: any[] = await Event.find({ club: params.id }, {
     name: 1,
@@ -49,6 +49,7 @@ export async function GET(
       username: admin.username,
       nickname: admin.nickname,
       image: admin.image || null,
+      avatarUpdatedAt: admin.avatarUpdatedAt,
     })),
     members: members.map(m => ({
       id: m._id.toString(),
@@ -57,6 +58,7 @@ export async function GET(
       gender: m.gender,
       image: m.image || null,
       role: m.role,
+      avatarUpdatedAt: m.avatarUpdatedAt,
     })),
     events: events.map(e => ({
       id: e._id.toString(),

--- a/app/api/eventRanking/route.ts
+++ b/app/api/eventRanking/route.ts
@@ -15,15 +15,15 @@ export async function GET(request: Request) {
 
   try {
     // Get event with participants
-    const event = await Event.findById(eventId).populate('participants', 'username email image');
+    const event = await Event.findById(eventId).populate('participants', 'username email image avatarUpdatedAt');
     if (!event) {
       return NextResponse.json({ success: false, error: 'Event not found' }, { status: 404 });
     }
 
     // Get all matches for this event (both regular and quick matches)
     const matches = await Match.find({ event: eventId })
-      .populate('teams.0.players', 'username email image')
-      .populate('teams.1.players', 'username email image');
+      .populate('teams.0.players', 'username email image avatarUpdatedAt')
+      .populate('teams.1.players', 'username email image avatarUpdatedAt');
 
     // Calculate ranking for each participant
     const rankingMap: Record<string, {
@@ -43,7 +43,8 @@ export async function GET(request: Request) {
           id: userId,
           username: participant.username || participant.email,
           email: participant.email,
-          image: participant.image
+          image: participant.image,
+          avatarUpdatedAt: participant.avatarUpdatedAt
         },
         wins: 0,
         losses: 0,

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -11,7 +11,7 @@ export async function GET(
 ) {
   await connect();
   const event: any = await Event.findById(params.id)
-    .populate('participants', 'username nickname image')
+    .populate('participants', 'username nickname image avatarUpdatedAt')
     .populate('club', 'name')
     .lean();
   if (!event) {
@@ -22,6 +22,7 @@ export async function GET(
     username: p.username,
     nickname: p.nickname,
     image: p.image || null,
+    avatarUpdatedAt: p.avatarUpdatedAt,
   }));
   return NextResponse.json({
     event: {

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -30,6 +30,7 @@ export async function POST(request: Request) {
     nickname: user.nickname,
     role: user.role,
     image: user.image,
+    avatarUpdatedAt: user.avatarUpdatedAt,
     clubs: Array.isArray(user.clubs)
       ? (user.clubs as any[]).map(c => c.name)
       : [],
@@ -75,6 +76,7 @@ export async function GET() {
       nickname: user.nickname,
       role: user.role,
       image: user.image,
+      avatarUpdatedAt: user.avatarUpdatedAt,
       clubs: Array.isArray(user.clubs)
         ? (user.clubs as any[]).map(c => c.name)
         : [],

--- a/app/clubs/[id]/ClubContext.tsx
+++ b/app/clubs/[id]/ClubContext.tsx
@@ -7,6 +7,7 @@ interface Member {
   nickname?: string;
   gender?: string;
   image?: string | null;
+  avatarUpdatedAt?: string | number | null;
 }
 
 interface AdminUser {
@@ -14,6 +15,7 @@ interface AdminUser {
   username: string;
   nickname?: string;
   image?: string | null;
+  avatarUpdatedAt?: string | number | null;
 }
 
 interface EventItem {

--- a/app/clubs/[id]/club-members/page.tsx
+++ b/app/clubs/[id]/club-members/page.tsx
@@ -15,6 +15,7 @@ interface Member {
   nickname?: string;
   gender?: string;
   image?: string | null;
+  avatarUpdatedAt?: string | number | null;
 }
 
 interface EventItem {

--- a/components/UserMiniCard.tsx
+++ b/components/UserMiniCard.tsx
@@ -8,6 +8,7 @@ export interface UserMiniCardProps {
     username: string
     nickname?: string
     image?: string | null
+    avatarUpdatedAt?: string | number | null
   },
   className?: string
 }
@@ -20,7 +21,11 @@ export default function UserMiniCard({ user, className }: UserMiniCardProps) {
     >
       {user.image ? (
         <Image
-          src={user.image}
+          src={
+            user.image
+              ? `${user.image}${user.avatarUpdatedAt ? `?v=${new Date(user.avatarUpdatedAt).getTime()}` : ''}`
+              : ''
+          }
           alt={displayName}
           width={32}
           height={32}

--- a/components/event/EventRanking.tsx
+++ b/components/event/EventRanking.tsx
@@ -30,6 +30,7 @@ interface RankingData {
     username: string
     email: string
     image?: string
+    avatarUpdatedAt?: string | number | null
   }
   wins: number
   losses: number
@@ -78,7 +79,11 @@ export default function EventRanking({ eventId }: EventRankingProps) {
           <div className="flex items-center space-x-3">
             {user.image ? (
               <Image
-                src={user.image}
+                src={
+                  user.image
+                    ? `${user.image}${user.avatarUpdatedAt ? `?v=${new Date(user.avatarUpdatedAt).getTime()}` : ''}`
+                    : ''
+                }
                 alt={displayName}
                 width={32}
                 height={32}

--- a/components/event/MatchLobby.tsx
+++ b/components/event/MatchLobby.tsx
@@ -195,27 +195,30 @@ export default function MatchLobby({
 		const status = getMatchStatus(match)
 		if (status === 'waiting') {
 			// In waiting state, all players are in team 0
-			return (match.teams[0]?.players || []).map(p => ({
-				id: (p as any)._id || (p as any).id || '',
-				username: p.username || p.nickname || p.email || 'Unknown',
-				image: p.image || null
-			}))
-		} else {
-			// In playing/completed state, players are in both teams
-			return [
-				...(match.teams[0]?.players || []).map(p => ({
-					id: (p as any)._id || (p as any).id || '',
-					username: p.username || p.nickname || p.email || 'Unknown',
-					image: p.image || null
-				})),
-				...(match.teams[1]?.players || []).map(p => ({
-					id: (p as any)._id || (p as any).id || '',
-					username: p.username || p.nickname || p.email || 'Unknown',
-					image: p.image || null
-				}))
-			]
-		}
-	}
+                        return (match.teams[0]?.players || []).map(p => ({
+                                id: (p as any)._id || (p as any).id || '',
+                                username: p.username || p.nickname || p.email || 'Unknown',
+                                image: p.image || null,
+                                avatarUpdatedAt: (p as any).avatarUpdatedAt || null
+                        }))
+                } else {
+                        // In playing/completed state, players are in both teams
+                        return [
+                                ...(match.teams[0]?.players || []).map(p => ({
+                                        id: (p as any)._id || (p as any).id || '',
+                                        username: p.username || p.nickname || p.email || 'Unknown',
+                                        image: p.image || null,
+                                        avatarUpdatedAt: (p as any).avatarUpdatedAt || null
+                                })),
+                                ...(match.teams[1]?.players || []).map(p => ({
+                                        id: (p as any)._id || (p as any).id || '',
+                                        username: p.username || p.nickname || p.email || 'Unknown',
+                                        image: p.image || null,
+                                        avatarUpdatedAt: (p as any).avatarUpdatedAt || null
+                                }))
+                        ]
+                }
+        }
 
 	const isUserInMatch = (match: MatchUI): boolean => {
 		const allPlayers = getAllPlayers(match)
@@ -325,14 +328,15 @@ export default function MatchLobby({
 												{/* Team 1 */}
 												<div className="flex flex-col gap-2 flex-1 min-w-0 overflow-hidden">
 													{(match.teams?.[0]?.players || []).map((player, index) => (
-														<UserMiniCard
-															key={index}
-															user={{
-																id: (player as any)._id || (player as any).id || '',
-																username: player.username || player.nickname || player.email || 'Unknown',
-																image: player.image || null
-															}}
-														/>
+                                                                              <UserMiniCard
+                                                                              key={index}
+                                                                              user={{
+                                                                               id: (player as any)._id || (player as any).id || '',
+                                                                               username: player.username || player.nickname || player.email || 'Unknown',
+                                                                               image: player.image || null,
+                                                                               avatarUpdatedAt: (player as any).avatarUpdatedAt || null
+                                                                              }}
+                                                                              />
 													))}
 													{/* Team 1 Score */}
 													<div className="text-center mt-2">
@@ -348,15 +352,16 @@ export default function MatchLobby({
 												{/* Team 2 */}
 												<div className="flex flex-col gap-2 flex-1 min-w-0 overflow-hidden">
 													{(match.teams?.[1]?.players || []).map((player, index) => (
-														<UserMiniCard
-															key={index}
-															user={{
-																id: (player as any)._id || (player as any).id || '',
-																username: player.username || player.nickname || player.email || 'Unknown',
-																image: player.image || null
-															}}
-															className="w-full max-w-full"
-														/>
+                                                                              <UserMiniCard
+                                                                              key={index}
+                                                                              user={{
+                                                                               id: (player as any)._id || (player as any).id || '',
+                                                                               username: player.username || player.nickname || player.email || 'Unknown',
+                                                                               image: player.image || null,
+                                                                               avatarUpdatedAt: (player as any).avatarUpdatedAt || null
+                                                                              }}
+                                                                              className="w-full max-w-full"
+                                                                              />
 													))}
 													{/* Team 2 Score */}
 													<div className="text-center mt-2">

--- a/components/event/RegistrationSection.tsx
+++ b/components/event/RegistrationSection.tsx
@@ -8,6 +8,7 @@ export interface Participant {
     username?: string
     nickname?: string
     image?: string | null
+    avatarUpdatedAt?: string | number | null // Add this line
 }
 
 interface RegistrationSectionProps {
@@ -23,6 +24,14 @@ export default function RegistrationSection({
     isAdmin,
     onRemoveParticipant
 }: RegistrationSectionProps) {
+    // Helper for cache-busting avatar URL
+    function getAvatarUrl(image?: string | null, avatarUpdatedAt?: string | number | null) {
+        if (!image) return '';
+        return avatarUpdatedAt
+            ? `${image}?v=${new Date(avatarUpdatedAt).getTime()}`
+            : image;
+    }
+
     return (
         <Card>
             <CardHeader>
@@ -37,7 +46,7 @@ export default function RegistrationSection({
                         <div className="flex items-center space-x-2">
                             {p.image && (
                                 <img
-                                    src={p.image}
+                                    src={getAvatarUrl(p.image, p.avatarUpdatedAt)}
                                     alt={p.nickname || p.username}
                                     className="h-6 w-6 rounded-full"
                                 />


### PR DESCRIPTION
## Summary
- ensure profile route returns avatar update timestamp
- return avatarUpdatedAt for club and event participants
- append avatarUpdatedAt to user image URLs
- pass avatarUpdatedAt through user cards and lobby

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685efb50b2588321b6fc792e53faaf1c