### PR TITLE
Add club search bar

### DIFF
--- a/app/clubs/page.tsx
+++ b/app/clubs/page.tsx
@@ -6,6 +6,7 @@ import ClubCard from '../../components/ClubCard'
 import PageSkeleton from '../../components/PageSkeleton'
 import { useApi } from '../../lib/useApi'
 import { useTranslation } from 'react-i18next'
+import { Input } from '../../components/ui/input'
 
 interface ClubItem {
   id: string
@@ -21,6 +22,7 @@ export default function ClubsDirectory() {
   const { data: session, status } = useSession()
   const { request, loading, error } = useApi()
   const [clubs, setClubs] = useState<ClubItem[]>([])
+  const [search, setSearch] = useState('')
   const { t } = useTranslation('common')
   
   useEffect(() => {
@@ -50,14 +52,26 @@ export default function ClubsDirectory() {
     return <div className="p-4">{t('loadFailed')}</div>
   }
 
+  const filteredClubs = clubs.filter(c =>
+    c.name.toLowerCase().includes(search.toLowerCase())
+  )
+
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl mb-2">{t('clubsDirectory')}</h1>
-      {clubs.length === 0 ? (
+      {clubs.length > 0 && (
+        <Input
+          placeholder={t('searchClubs')}
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="max-w-xs"
+        />
+      )}
+      {filteredClubs.length === 0 ? (
         <p>{t('noClubsAvailable')}</p>
       ) : (
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {clubs.map(c => (
+          {filteredClubs.map(c => (
             <Link key={c.id} href={`/clubs/${c.id}`} className="block">
               <ClubCard club={c} />
             </Link>

--- a/app/i18n/en/common.json
+++ b/app/i18n/en/common.json
@@ -115,6 +115,7 @@
   "confirm": "Confirm",
   "cancel": "Cancel",
   "searchUsers": "Search users",
+  "searchClubs": "Search clubs",
   "signupTitle": "Sign Up",
   "signupWithGoogle": "Sign Up With Google",
   "alreadyHaveAccount": "Already have an account? Login",

--- a/app/i18n/es/common.json
+++ b/app/i18n/es/common.json
@@ -115,6 +115,7 @@
     "confirm": "Confirmar",
     "cancel": "Cancelar",
     "searchUsers": "Buscar usuarios",
+    "searchClubs": "Buscar clubes",
     "signupTitle": "Registrarse",
     "signupWithGoogle": "Regístrate con Google",
     "alreadyHaveAccount": "¿Ya tienes una cuenta? Inicia sesión",

--- a/app/i18n/vi/common.json
+++ b/app/i18n/vi/common.json
@@ -115,6 +115,7 @@
     "confirm": "Xác nhận",
     "cancel": "Hủy bỏ",
     "searchUsers": "Tìm kiếm người dùng",
+    "searchClubs": "Tìm kiếm câu lạc bộ",
     "signupTitle": "Đăng ký",
     "signupWithGoogle": "Đăng ký bằng Google",
     "alreadyHaveAccount": "Đã có tài khoản? Đăng nhập",

--- a/app/i18n/zh/common.json
+++ b/app/i18n/zh/common.json
@@ -115,6 +115,7 @@
   "confirm": "确认",
   "cancel": "取消",
   "searchUsers": "搜索用户",
+  "searchClubs": "搜索俱乐部",
   "signupTitle": "注册",
   "signupWithGoogle": "使用 Google 注册",
   "alreadyHaveAccount": "已有账号？登录",


### PR DESCRIPTION
## Summary
- add search filter on clubs page
- localize `searchClubs` text in all languages
- run lint and build

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f695362408321827f3155d49191b8