### PR TITLE
PAIMO-65 Implement club roles with management UI

### DIFF
--- a/app/api/clubs/[id]/role/route.ts
+++ b/app/api/clubs/[id]/role/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../../../../auth';
+import connect from '../../../../../utils/mongoose';
+import Club from '../../../../../models/Club';
+
+export async function PUT(request: Request, { params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user) {
+    return NextResponse.json({ success: false }, { status: 401 });
+  }
+  const { memberId, role } = await request.json();
+  if (!memberId || !role) {
+    return NextResponse.json({ success: false }, { status: 400 });
+  }
+  await connect();
+  const club: any = await Club.findById(params.id);
+  if (!club) {
+    return NextResponse.json({ success: false }, { status: 404 });
+  }
+  const requester = club.members.find((m: any) => m.id.toString() === session.user.id);
+  const requesterRole = requester?.role;
+  const isSuperAdmin = session.user.role === 'super-admin';
+  if (!isSuperAdmin && requesterRole !== 'president' && requesterRole !== 'vice') {
+    return NextResponse.json({ success: false }, { status: 403 });
+  }
+  const target = club.members.find((m: any) => m.id.toString() === memberId);
+  if (!target) {
+    return NextResponse.json({ success: false }, { status: 404 });
+  }
+  if (target.role === 'president' && requesterRole !== 'president' && !isSuperAdmin) {
+    return NextResponse.json({ success: false }, { status: 403 });
+  }
+  target.role = role;
+  if (role === 'president' || role === 'vice') {
+    if (!club.adminList.some((a: any) => a.toString() === memberId)) {
+      club.adminList.push(memberId);
+    }
+  } else {
+    club.adminList = club.adminList.filter((a: any) => a.toString() !== memberId);
+  }
+  await club.save();
+  return NextResponse.json({ success: true });
+}

--- a/app/api/clubs/[id]/role/route.ts
+++ b/app/api/clubs/[id]/role/route.ts
@@ -21,7 +21,7 @@ export async function PUT(request: Request, { params }: { params: { id: string }
   const requester = club.members.find((m: any) => m.id.toString() === session.user.id);
   const requesterRole = requester?.role;
   const isSuperAdmin = session.user.role === 'super-admin';
-  if (!isSuperAdmin && requesterRole !== 'president' && requesterRole !== 'vice') {
+  if (!isSuperAdmin && requesterRole !== 'president') {
     return NextResponse.json({ success: false }, { status: 403 });
   }
   const target = club.members.find((m: any) => m.id.toString() === memberId);

--- a/app/api/clubs/[id]/route.ts
+++ b/app/api/clubs/[id]/route.ts
@@ -22,8 +22,20 @@ export async function GET(
   const memberIds = club.members.map((m: any) => m.id);
   const members: any[] = await User.find(
     { _id: { $in: memberIds } },
-    { username: 1, nickname: 1, gender: 1, image: 1, role: 1, avatarUpdatedAt: 1 }
+    { username: 1, nickname: 1, gender: 1, image: 1, avatarUpdatedAt: 1 }
   ).lean();
+  const membersWithRole = members.map(m => {
+    const clubMember = club.members.find((cm: any) => cm.id.toString() === m._id.toString());
+    return {
+      id: m._id.toString(),
+      username: m.username,
+      nickname: m.nickname,
+      gender: m.gender,
+      image: m.image || null,
+      role: clubMember?.role || 'member',
+      avatarUpdatedAt: m.avatarUpdatedAt,
+    };
+  });
   const events: any[] = await Event.find({ club: params.id }, {
     name: 1,
     status: 1,
@@ -51,15 +63,7 @@ export async function GET(
       image: admin.image || null,
       avatarUpdatedAt: admin.avatarUpdatedAt,
     })),
-    members: members.map(m => ({
-      id: m._id.toString(),
-      username: m.username,
-      nickname: m.nickname,
-      gender: m.gender,
-      image: m.image || null,
-      role: m.role,
-      avatarUpdatedAt: m.avatarUpdatedAt,
-    })),
+    members: membersWithRole,
     events: events.map(e => ({
       id: e._id.toString(),
       name: e.name,
@@ -93,7 +97,7 @@ export async function POST(
   const username = user.username || user.email || 'unknown';
   const already = club.members.some((m: any) => m.id.toString() === user._id.toString());
   if (!already) {
-    club.members.push({ id: user._id, username });
+    club.members.push({ id: user._id, username, role: 'member' });
     await club.save();
   }
   if (!Array.isArray(user.clubs)) user.clubs = [];

--- a/app/api/clubs/route.ts
+++ b/app/api/clubs/route.ts
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
     visibility,
     createdBy: user?.nickname || user?.username,
     createdAt: new Date(),
-    members: [{ id: user._id, username: user?.username || user?.email || 'unknown' }],
+    members: [{ id: user._id, username: user?.username || user?.email || 'unknown', role: 'president' }],
     adminList: [user._id], // Auto-assign club creator as admin
   });
   // also store the club reference on user for convenience

--- a/app/clubs/[id]/ClubContext.tsx
+++ b/app/clubs/[id]/ClubContext.tsx
@@ -7,6 +7,7 @@ interface Member {
   nickname?: string;
   gender?: string;
   image?: string | null;
+  role?: string;
   avatarUpdatedAt?: string | number | null;
 }
 

--- a/app/clubs/[id]/club-event/page.tsx
+++ b/app/clubs/[id]/club-event/page.tsx
@@ -15,6 +15,14 @@ interface Member {
   nickname?: string;
   gender?: string;
   image?: string | null;
+  role?: string;
+}
+
+interface AdminUser {
+  id: string;
+  username: string;
+  nickname?: string;
+  image?: string | null;
 }
 
 interface EventItem {
@@ -44,6 +52,7 @@ interface ClubData {
   club: Club;
   members: Member[];
   events: EventItem[];
+  adminList: AdminUser[];
   isMember: boolean;
   isAdmin: boolean;
 }
@@ -66,12 +75,14 @@ export default function ClubEventPage({ params }: { params: { id: string } }) {
 
   const fetchClubData = async () => {
     try {
-      const res = await request<{ club: any; members: Member[]; events: EventItem[] }>({
+      const res = await request<{ club: any; members: Member[]; events: EventItem[]; adminList: AdminUser[] }>({
         url: `/api/clubs/${params.id}`,
         method: 'get',
       });
-      
-      const isAdmin = session?.user?.role === 'admin' || session?.user?.role === 'super-admin';
+
+      const isClubAdmin = res.adminList.some((a: AdminUser) => a.id === session?.user?.id);
+      const isSuperAdmin = session?.user?.role === 'super-admin';
+      const isAdmin = isClubAdmin || isSuperAdmin;
       const isMember = res.members.some((m: Member) => m.id === session?.user?.id);
 
       setClubData({
@@ -87,6 +98,7 @@ export default function ClubEventPage({ params }: { params: { id: string } }) {
         },
         members: res.members,
         events: res.events.map(e => ({ ...e, clubName: res.club.name })),
+        adminList: res.adminList,
         isMember,
         isAdmin,
       });

--- a/app/clubs/[id]/club-home/page.tsx
+++ b/app/clubs/[id]/club-home/page.tsx
@@ -239,7 +239,8 @@ export default function ClubHomePage() {
         </Card>
       )}
 
-      {clubData.isAdmin && (
+      {(clubData.isAdmin &&
+        (session?.user?.role === 'super-admin' || currentUserRole === 'president')) && (
         <Card>
           <CardHeader>
             <CardTitle>{t('manageRoles')}</CardTitle>

--- a/app/clubs/[id]/club-home/page.tsx
+++ b/app/clubs/[id]/club-home/page.tsx
@@ -27,6 +27,7 @@ export default function ClubHomePage() {
   const [savingLocation, setSavingLocation] = useState(false);
   const [savingVisibility, setSavingVisibility] = useState(false);
   const [showLeave, setShowLeave] = useState(false);
+  const currentUserRole = clubData?.members.find(m => m.id === session?.user?.id)?.role;
 
   // Update local state when clubData changes
   useEffect(() => {
@@ -87,6 +88,15 @@ export default function ClubHomePage() {
       data: { visibility: newVisibility },
     });
     setSavingVisibility(false);
+    fetchClubData();
+  };
+
+  const handleRoleChange = async (memberId: string, role: string) => {
+    await request({
+      url: `/api/clubs/${clubData.club.id}/role`,
+      method: 'put',
+      data: { memberId, role },
+    });
     fetchClubData();
   };
 
@@ -225,6 +235,39 @@ export default function ClubHomePage() {
                 <UserCard key={admin.id} user={admin} />
               ))}
             </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {clubData.isAdmin && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t('manageRoles')}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {clubData.members.map(member => (
+              <div key={member.id} className="flex items-center justify-between">
+                <UserCard user={member} />
+                <Select
+                  value={member.role || 'member'}
+                  onValueChange={value => handleRoleChange(member.id, value)}
+                  disabled={
+                    member.role === 'president' &&
+                    currentUserRole !== 'president' &&
+                    session?.user?.role !== 'super-admin'
+                  }
+                >
+                  <SelectTrigger className="w-32 text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="president">{t('president')}</SelectItem>
+                    <SelectItem value="vice">{t('vicePresident')}</SelectItem>
+                    <SelectItem value="member">{t('member')}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            ))}
           </CardContent>
         </Card>
       )}

--- a/app/clubs/[id]/club-members/page.tsx
+++ b/app/clubs/[id]/club-members/page.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 import UserCard from '@/components/UserCard';
 import PageSkeleton from '@/components/PageSkeleton';
 import { useApi } from '@/lib/useApi';
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
 
 interface Member {
   id: string;
@@ -110,14 +109,6 @@ export default function ClubMembersPage({ params }: { params: { id: string } }) 
     }
   };
 
-  const handleRoleChange = async (memberId: string, role: string) => {
-    await request({
-      url: `/api/clubs/${params.id}/role`,
-      method: 'put',
-      data: { memberId, role },
-    });
-    fetchClubData();
-  };
 
   if (status === 'loading' || loading) {
     return <PageSkeleton />;
@@ -140,7 +131,6 @@ export default function ClubMembersPage({ params }: { params: { id: string } }) 
     !m.gender || (m.gender !== 'male' && m.gender !== 'Male' && m.gender !== 'female' && m.gender !== 'Female')
   ).length;
 
-  const currentUserRole = clubData.members.find(m => m.id === session?.user?.id)?.role;
 
   return (
     <div className="p-4">
@@ -196,21 +186,14 @@ export default function ClubMembersPage({ params }: { params: { id: string } }) 
                 <div key={member.id} className="flex items-center justify-between">
                   <UserCard user={member} />
                   <div className="flex items-center gap-2">
-                    {clubData.isAdmin && (
-                      <Select
-                        value={member.role || 'member'}
-                        onValueChange={value => handleRoleChange(member.id, value)}
-                        disabled={member.role === 'president' && currentUserRole !== 'president' && session?.user?.role !== 'super-admin'}
-                      >
-                        <SelectTrigger className="w-32 text-xs">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="president">{t('president')}</SelectItem>
-                          <SelectItem value="vice">{t('vicePresident')}</SelectItem>
-                          <SelectItem value="member">{t('member')}</SelectItem>
-                        </SelectContent>
-                      </Select>
+                    {member.role && (
+                      <Badge variant="secondary" className="text-xs">
+                        {member.role === 'president'
+                          ? t('president')
+                          : member.role === 'vice'
+                          ? t('vicePresident')
+                          : t('member')}
+                      </Badge>
                     )}
                     {member.gender && (
                       <Badge

--- a/app/clubs/[id]/layout.tsx
+++ b/app/clubs/[id]/layout.tsx
@@ -13,6 +13,7 @@ interface Member {
   nickname?: string;
   gender?: string;
   image?: string | null;
+  role?: string;
 }
 
 interface AdminUser {

--- a/app/i18n/en/common.json
+++ b/app/i18n/en/common.json
@@ -93,6 +93,8 @@
   "createClub": "Create Club",
   "superAdmin": "Super Admin",
   "admin": "Admin",
+  "president": "President",
+  "vicePresident": "Vice President",
   "member": "Member",
   "clubDirectory": "Club Directory",
   "myClubs": "My Clubs",

--- a/app/i18n/en/common.json
+++ b/app/i18n/en/common.json
@@ -96,6 +96,7 @@
   "president": "President",
   "vicePresident": "Vice President",
   "member": "Member",
+  "manageRoles": "Manage Roles",
   "clubDirectory": "Club Directory",
   "myClubs": "My Clubs",
   "clubsDirectory": "Clubs Directory",

--- a/app/i18n/es/common.json
+++ b/app/i18n/es/common.json
@@ -93,6 +93,8 @@
     "createClub": "Crear club",
     "superAdmin": "Super administrador",
     "admin": "Administrador",
+    "president": "Presidente",
+    "vicePresident": "Vicepresidente",
     "member": "Miembro",
     "clubDirectory": "Directorio de clubes",
     "myClubs": "Mis Clubes",

--- a/app/i18n/es/common.json
+++ b/app/i18n/es/common.json
@@ -96,6 +96,7 @@
     "president": "Presidente",
     "vicePresident": "Vicepresidente",
     "member": "Miembro",
+    "manageRoles": "Administrar roles",
     "clubDirectory": "Directorio de clubes",
     "myClubs": "Mis Clubes",
     "clubsDirectory": "Directorio de clubes",

--- a/app/i18n/vi/common.json
+++ b/app/i18n/vi/common.json
@@ -96,6 +96,7 @@
     "president": "Chủ tịch",
     "vicePresident": "Phó chủ tịch",
     "member": "Thành viên",
+    "manageRoles": "Quản lý vai trò",
     "clubDirectory": "Thư mục câu lạc bộ",
     "myClubs": "Câu lạc bộ của tôi",
     "clubsDirectory": "Thư mục câu lạc bộ",

--- a/app/i18n/vi/common.json
+++ b/app/i18n/vi/common.json
@@ -93,6 +93,8 @@
     "createClub": "Tạo câu lạc bộ",
     "superAdmin": "Quản trị viên",
     "admin": "Quản trị viên",
+    "president": "Chủ tịch",
+    "vicePresident": "Phó chủ tịch",
     "member": "Thành viên",
     "clubDirectory": "Thư mục câu lạc bộ",
     "myClubs": "Câu lạc bộ của tôi",

--- a/app/i18n/zh/common.json
+++ b/app/i18n/zh/common.json
@@ -93,6 +93,8 @@
   "createClub": "创建俱乐部",
   "superAdmin": "超级管理员",
   "admin": "管理员",
+  "president": "会长",
+  "vicePresident": "副会长",
   "member": "成员",
   "clubDirectory": "俱乐部目录",
   "myClubs": "我的俱乐部",

--- a/app/i18n/zh/common.json
+++ b/app/i18n/zh/common.json
@@ -96,6 +96,7 @@
   "president": "会长",
   "vicePresident": "副会长",
   "member": "成员",
+  "manageRoles": "管理角色",
   "clubDirectory": "俱乐部目录",
   "myClubs": "我的俱乐部",
   "clubsDirectory": "俱乐部目录",

--- a/models/Club.ts
+++ b/models/Club.ts
@@ -17,6 +17,11 @@ const clubSchema = new Schema({
     {
       id: { type: Schema.Types.ObjectId, ref: 'User' },
       username: String,
+      role: {
+        type: String,
+        enum: ['president', 'vice', 'member'],
+        default: 'member',
+      },
     },
   ],
   adminList: [{ type: Schema.Types.ObjectId, ref: 'User' }],


### PR DESCRIPTION
## Summary
- add role field to `Club` model
- include role on club members API
- add endpoint to update club member roles
- allow admins to change member roles in UI
- translate new role labels

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f732825e8832184b1af42de53907f