### PR TITLE
Improve chat message layout

### DIFF
--- a/app/api/clubs/[id]/messages/route.ts
+++ b/app/api/clubs/[id]/messages/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth/next'
 import { authOptions } from '../../../../../auth'
 import { getDb } from '@/lib/db'
+import { ObjectId } from 'mongodb'
 import Pusher from 'pusher'
 
 const pusher = new Pusher({
@@ -23,7 +24,34 @@ export async function GET(
     .sort({ timestamp: -1 })
     .limit(50)
     .toArray()
-  return NextResponse.json({ messages: messages.reverse() })
+
+  const userIds = Array.from(
+    new Set(messages.map(m => m.senderId).filter(Boolean))
+  )
+  const users = await db
+    .collection('users')
+    .find(
+      { _id: { $in: userIds.map(id => new ObjectId(id)) } },
+      { projection: { username: 1, email: 1, nickname: 1, image: 1 } }
+    )
+    .toArray()
+  const map = new Map(
+    users.map(u => [u._id.toString(), u])
+  )
+  const result = messages
+    .reverse()
+    .map(m => ({
+      ...m,
+      senderNickname:
+        m.senderNickname ||
+        map.get(m.senderId)?.nickname ||
+        map.get(m.senderId)?.username ||
+        map.get(m.senderId)?.email ||
+        m.senderName,
+      senderAvatarUrl: m.senderAvatarUrl || map.get(m.senderId)?.image || null,
+    }))
+
+  return NextResponse.json({ messages: result })
 }
 
 export async function POST(
@@ -39,17 +67,25 @@ export async function POST(
     return NextResponse.json({ success: false }, { status: 400 })
   }
   const db = await getDb()
-  const user = session.user as any
+  const user = await db.collection('users').findOne(
+    { _id: new ObjectId(session.user.id) },
+    { projection: { username: 1, email: 1, nickname: 1, image: 1 } }
+  )
   const doc = {
     clubId: params.id,
     senderId: session.user.id,
-    senderName: user.username || user.email || 'anonymous',
+    senderName: user?.username || user?.email || 'anonymous',
+    senderNickname: user?.nickname || user?.username || user?.email || 'anonymous',
+    senderAvatarUrl: user?.image || null,
     content,
     timestamp: new Date(),
   }
   await db.collection('messages').insertOne(doc)
   await pusher.trigger(`club-${params.id}`, 'message', {
+    senderId: doc.senderId,
     senderName: doc.senderName,
+    senderNickname: doc.senderNickname,
+    senderAvatarUrl: doc.senderAvatarUrl,
     content: doc.content,
     timestamp: doc.timestamp,
   })

--- a/components/club/ChatBox.tsx
+++ b/components/club/ChatBox.tsx
@@ -3,11 +3,17 @@
 import { useEffect, useRef, useState } from 'react'
 import Pusher from 'pusher-js'
 import axios from 'axios'
+import Image from 'next/image'
+import Avatar from 'boring-avatars'
+import dayjs from 'dayjs'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 
 interface Message {
+  senderId: string
   senderName: string
+  senderNickname?: string
+  senderAvatarUrl?: string | null
   content: string
   timestamp?: string
 }
@@ -68,17 +74,44 @@ export default function ChatBox({ clubId }: { clubId: string }) {
   }
 
   return (
-    <div className="border rounded-md p-4 space-y-2">
-      <div className="h-64 sm:h-96 max-h-[70vh] overflow-y-auto space-y-1" style={{ scrollBehavior: 'smooth' }}>
+    <div className="flex flex-col h-screen">
+      <div
+        className="flex-1 overflow-y-auto p-4 space-y-4"
+        style={{ scrollBehavior: 'smooth' }}
+      >
         {messages.map((m, idx) => (
-          <div key={idx} className="p-1 border-b text-sm">
-            <strong>{m.senderName}: </strong>
-            {m.content}
+          <div key={idx} className="flex items-start gap-2">
+            {m.senderAvatarUrl ? (
+              <Image
+                src={m.senderAvatarUrl}
+                alt={m.senderNickname || m.senderName}
+                width={32}
+                height={32}
+                className="w-8 h-8 rounded-full object-cover"
+              />
+            ) : (
+              <Avatar size={32} name={m.senderNickname || m.senderName} variant="beam" />
+            )}
+            <div>
+              <div className="flex items-center gap-2">
+                <span className="font-medium text-sm">
+                  {m.senderNickname || m.senderName}
+                </span>
+                {m.timestamp && (
+                  <span className="text-xs text-gray-500">
+                    {dayjs(m.timestamp).format('HH:mm')}
+                  </span>
+                )}
+              </div>
+              <div className="bg-gray-100 rounded-lg px-3 py-2 mt-1 text-sm whitespace-pre-wrap break-words">
+                {m.content}
+              </div>
+            </div>
           </div>
         ))}
         <div ref={bottomRef} />
       </div>
-      <div className="flex gap-2">
+      <div className="p-2 border-t bg-white flex gap-2 sticky bottom-0">
         <Input
           value={input}
           onChange={e => setInput(e.target.value)}


### PR DESCRIPTION
## Summary
- style Club chat messages with avatars, nicknames and timestamps
- update message API to include nickname and avatar info

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686086d814b8832192ac4fd9e10f5ec4