### PR TITLE
Add web push notifications

### DIFF
--- a/app/Providers.tsx
+++ b/app/Providers.tsx
@@ -6,6 +6,7 @@ import { SessionProvider } from "next-auth/react";
 import type { ReactNode } from "react";
 import type { Session } from "next-auth";
 import { I18nProvider } from "./providers/I18nProvider";
+import PushInit from "./PushInit";
 
 export function Providers({
   children,
@@ -17,6 +18,7 @@ export function Providers({
   return (
     <SessionProvider session={session}>
       <I18nProvider>
+        <PushInit />
         <div className="flex flex-col h-full w-full">
           <AppBar />
           <main className="flex-grow overflow-y-auto">{children}</main>

--- a/app/PushInit.tsx
+++ b/app/PushInit.tsx
@@ -1,0 +1,39 @@
+'use client'
+import { useEffect } from 'react'
+import axios from 'axios'
+
+function urlBase64ToUint8Array(base64: string) {
+  const padding = '='.repeat((4 - (base64.length % 4)) % 4)
+  const base64Data = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const rawData = atob(base64Data)
+  const output = new Uint8Array(rawData.length)
+  for (let i = 0; i < rawData.length; ++i) {
+    output[i] = rawData.charCodeAt(i)
+  }
+  return output
+}
+
+export default function PushInit() {
+  useEffect(() => {
+    if (!('serviceWorker' in navigator) || !('PushManager' in window)) return
+    const setup = async () => {
+      try {
+        const reg = await navigator.serviceWorker.register('/sw.js')
+        let sub = await reg.pushManager.getSubscription()
+        if (!sub) {
+          const key = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY
+          if (!key) return
+          sub = await reg.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(key),
+          })
+        }
+        await axios.post('/api/push/subscribe', sub)
+      } catch (err) {
+        console.error('Push setup failed', err)
+      }
+    }
+    setup()
+  }, [])
+  return null
+}

--- a/app/api/clubs/[id]/messages/route.ts
+++ b/app/api/clubs/[id]/messages/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from '../../../../../auth'
 import { getDb } from '@/lib/db'
 import { ObjectId } from 'mongodb'
 import Pusher from 'pusher'
+import { sendPushNotification } from '@/lib/push'
 
 const pusher = new Pusher({
   appId: process.env.PUSHER_APP_ID!,
@@ -89,5 +90,13 @@ export async function POST(
     content: doc.content,
     timestamp: doc.timestamp,
   })
+  await sendPushNotification(
+    {
+      title: doc.senderNickname,
+      body: doc.content,
+      icon: doc.senderAvatarUrl || undefined,
+    },
+    doc.senderId
+  )
   return NextResponse.json({ success: true })
 }

--- a/app/api/push/subscribe/route.ts
+++ b/app/api/push/subscribe/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '../../../../auth'
+import { getDb } from '@/lib/db'
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions)
+  if (!session || !session.user?.id) {
+    return NextResponse.json({ success: false }, { status: 401 })
+  }
+  const subscription = await request.json()
+  const db = await getDb()
+  await db.collection('push_subscriptions').updateOne(
+    { endpoint: subscription.endpoint },
+    { $set: { ...subscription, userId: session.user.id } },
+    { upsert: true }
+  )
+  return NextResponse.json({ success: true })
+}

--- a/lib/push.ts
+++ b/lib/push.ts
@@ -1,0 +1,27 @@
+import webpush from 'web-push'
+import { getDb } from './db'
+
+webpush.setVapidDetails(
+  'mailto:no-reply@example.com',
+  process.env.VAPID_PUBLIC_KEY!,
+  process.env.VAPID_PRIVATE_KEY!
+)
+
+export interface PushPayload {
+  title: string
+  body: string
+  icon?: string
+}
+
+export async function sendPushNotification(payload: PushPayload, excludeUserId?: string) {
+  const db = await getDb()
+  const query = excludeUserId ? { userId: { $ne: excludeUserId } } : {}
+  const subs = await db.collection('push_subscriptions').find(query).toArray()
+  await Promise.all(
+    subs.map(sub =>
+      webpush.sendNotification(sub, JSON.stringify(payload)).catch(err => {
+        console.error('Push error', err)
+      })
+    )
+  )
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "motion": "^12.19.1",
     "next": "^14.2.30",
     "next-auth": "^4.24.11",
+    "pusher": "^5.2.0",
+    "pusher-js": "^8.2.0",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.58.1",
@@ -46,8 +48,7 @@
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "use-haptic": "^1.1.11",
-    "pusher": "^5.2.0",
-    "pusher-js": "^8.2.0"
+    "web-push": "^3.6.7"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.18",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,21 @@
+self.addEventListener('push', event => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.title || 'New Notification';
+  const options = {
+    body: data.body,
+    icon: data.icon || '/icon-192x192.png',
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(clients => {
+      for (const client of clients) {
+        if ('focus' in client) return client.focus();
+      }
+      if (self.clients.openWindow) return self.clients.openWindow('/');
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- enable push notification service worker
- register push subscriptions from client
- store subscriptions via an API route
- send push notifications when new club messages arrive
- include `web-push` dependency

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b16ba80883218af964c7b09d7974